### PR TITLE
Updated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"test": "mocha ./test/test.js"
 	},
 	"dependencies": {
-		"redis": "2.4.2",
-		"lodash": "4.5.1"
+		"redis": "2.5.3",
+		"lodash": "4.6.1"
 	},
 	"optionalDependencies": {
 		"hiredis": "0.4.1"


### PR DESCRIPTION
In particular, this allows a redisClient to be passed in that was created using v2.5.x of the redis library.

As an aside, I'm wondering why the dependencies aren't specified with a caret? AFAIK, this is the preferred way of specifying dependencies for libraries, i.e. packages that others will use in their application. It means that bugfixes and new backwards-compatible features will be automatically installed when the app using your package runs `npm install`, but breaking changes won't be introduced.