### PR TITLE
Allow larger message sizes than 65k at own risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Parameters:
 * `vt` (Number): *optional* *(Default: 30)* The length of time, in seconds, that a message received from a queue will be invisible to other receiving components when they ask to receive messages. Allowed values: 0-9999999 (around 115 days)
 * `delay` (Number): *optional* *(Default: 0)* The time in seconds that the delivery of all new messages in the queue will be delayed. Allowed values: 0-9999999 (around 115 days)
 * `maxsize` (Number): *optional* *(Default: 65536)* The maximum message size in bytes. Allowed values: 1024-65536
+* `allowLargeMessages` (Boolean): *optional* *(Default: false)* If you want to allow use a  `maxsize` over 65536 set this to true
 
 Returns:
 

--- a/index.js
+++ b/index.js
@@ -568,7 +568,7 @@ RedisSMQ = (function(superClass) {
           break;
         case "maxsize":
           o[item] = parseInt(o[item], 10);
-          if (_.isNaN(o[item]) || !_.isNumber(o[item]) || o[item] < 1024 || o[item] > 65536) {
+          if (!o.allowLargeMessages && (_.isNaN(o[item]) || !_.isNumber(o[item]) || o[item] < 1024 || o[item] > 65536)) {
             this._handleError(cb, "invalidValue", {
               item: item,
               min: 1024,

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,7 @@ RedisInst = require("redis");
 
 redis = RedisInst.createClient();
 
-describe('Redis-Simple-Message-Queue Test', function() {
+describe('Redis-Simple-Message-Queue Test', function () {
   var q1m1, q1m2, q1m3, q2m2, q2msgs, queue1, queue2, rsmq, rsmq2;
   rsmq = null;
   rsmq2 = null;
@@ -24,175 +24,194 @@ describe('Redis-Simple-Message-Queue Test', function() {
   q1m3 = null;
   q2m2 = null;
   q2msgs = {};
-  before(function(done) {
+  before(function (done) {
     done();
   });
-  after(function(done) {
+  after(function (done) {
     done();
   });
-  it('get a RedisSMQ instance', function(done) {
+  it('get a RedisSMQ instance', function (done) {
     rsmq = new RedisSMQ();
     rsmq.should.be.an.instanceOf(RedisSMQ);
     done();
   });
-  it('use an existing Redis Client', function(done) {
+  it('use an existing Redis Client', function (done) {
     rsmq2 = new RedisSMQ({
       client: redis
     });
     rsmq2.should.be.an.instanceOf(RedisSMQ);
     done();
   });
-  describe('Queues', function() {
-    it('Should fail: Create a new queue with invalid characters in name', function(done) {
+  describe('Queues', function () {
+    it('Should fail: Create a new queue with invalid characters in name', function (done) {
       rsmq.createQueue({
         qname: "should throw"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Invalid qname format");
         done();
       });
     });
-    it('Should fail: Create a new queue with name longer 160 chars', function(done) {
+    it('Should fail: Create a new queue with name longer 160 chars', function (done) {
       rsmq.createQueue({
         qname: "name01234567890123456789012345678901234567890123456789012345678901234567890123456789name01234567890123456789012345678901234567890123456789012345678901234567890123456789"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Invalid qname format");
         done();
       });
     });
-    it('Should fail: Create a new queue with negative vt', function(done) {
+    it('Should fail: Create a new queue with negative vt', function (done) {
       rsmq.createQueue({
         qname: queue1,
         vt: -20
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("vt must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with non numeric vt', function(done) {
+    it('Should fail: Create a new queue with non numeric vt', function (done) {
       rsmq.createQueue({
         qname: queue1,
         vt: "not_a_number"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("vt must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with vt too high', function(done) {
+    it('Should fail: Create a new queue with vt too high', function (done) {
       rsmq.createQueue({
         qname: queue1,
         vt: 10000000
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("vt must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with negative delay', function(done) {
+    it('Should fail: Create a new queue with negative delay', function (done) {
       rsmq.createQueue({
         qname: queue1,
         delay: -20
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("delay must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with non numeric delay', function(done) {
+    it('Should fail: Create a new queue with non numeric delay', function (done) {
       rsmq.createQueue({
         qname: queue1,
         delay: "not_a_number"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("delay must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with delay too high', function(done) {
+    it('Should fail: Create a new queue with delay too high', function (done) {
       rsmq.createQueue({
         qname: queue1,
         delay: 10000000
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("delay must be between 0 and 9999999");
         done();
       });
     });
-    it('Should fail: Create a new queue with negative maxsize', function(done) {
+    it('Should fail: Create a new queue with negative maxsize', function (done) {
       rsmq.createQueue({
         qname: queue1,
         maxsize: -20
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("maxsize must be between 1024 and 65536");
         done();
       });
     });
-    it('Should fail: Create a new queue with non numeric maxsize', function(done) {
+    it('Should fail: Create a new queue with non numeric maxsize', function (done) {
       rsmq.createQueue({
         qname: queue1,
         maxsize: "not_a_number"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("maxsize must be between 1024 and 65536");
         done();
       });
     });
-    it('Should fail: Create a new queue with maxsize too high', function(done) {
+    it('Should fail: Create a new queue with maxsize too high', function (done) {
       rsmq.createQueue({
         qname: queue1,
         maxsize: 66000
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("maxsize must be between 1024 and 65536");
         done();
       });
     });
-    it('Should fail: Create a new queue with maxsize too low', function(done) {
+    it('Should fail: Create a new queue with maxsize too low', function (done) {
       rsmq.createQueue({
         qname: queue1,
         maxsize: 900
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("maxsize must be between 1024 and 65536");
         done();
       });
     });
-    it('ListQueues: Should return empty array', function(done) {
-      rsmq.listQueues(function(err, resp) {
+    it('ListQueues: Should return empty array', function (done) {
+      rsmq.listQueues(function (err, resp) {
         should.not.exist(err);
         resp.length.should.equal(0);
         done();
       });
     });
-    it('Create a new queue: queue1', function(done) {
+     
+    it('Create a new queue: queue1', function (done) {
       rsmq.createQueue({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.should.equal(1);
         done();
       });
     });
-    it('Should fail: Create the same queue again', function(done) {
+    it('Should fail: Create the same queue again', function (done) {
       rsmq.createQueue({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Queue exists");
         done();
       });
     });
-    it('ListQueues: Should return array with one element', function(done) {
-      rsmq.listQueues(function(err, resp) {
+    it('Should pass: Create a new queue with larger maxsize if allowLargeMessages: true', function (done) {
+      rsmq.createQueue({
+        qname: 'queueLargeMessages',
+        allowLargeMessages: true,
+        maxsize: 66000
+      }, function (err, resp) {
+          should.not.exist(err)
+          // remove queue
+          rsmq.deleteQueue({
+          qname: 'queueLargeMessages'
+        }, function (err, resp) {
+            should.not.exist(err);
+            resp.should.equal(1);
+            done();
+      });
+        
+      });
+    });
+    it('ListQueues: Should return array with one element', function (done) {
+      rsmq.listQueues(function (err, resp) {
         should.not.exist(err);
         resp.length.should.equal(1);
         resp.should.containEql(queue1);
         done();
       });
     });
-    it('Create a new queue: queue2', function(done) {
+    it('Create a new queue: queue2', function (done) {
       rsmq.createQueue({
         qname: queue2,
         maxsize: 2048
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.should.equal(1);
         done();
       });
     });
-    it('ListQueues: Should return array with two elements', function(done) {
-      rsmq.listQueues(function(err, resp) {
+    it('ListQueues: Should return array with two elements', function (done) {
+      rsmq.listQueues(function (err, resp) {
         should.not.exist(err);
         resp.length.should.equal(2);
         resp.should.containEql(queue1);
@@ -200,135 +219,135 @@ describe('Redis-Simple-Message-Queue Test', function() {
         done();
       });
     });
-    it('Should fail: GetQueueAttributes of bogus queue', function(done) {
+    it('Should fail: GetQueueAttributes of bogus queue', function (done) {
       rsmq.getQueueAttributes({
         qname: "sdfsdfsdf"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Queue not found");
         done();
       });
     });
-    it('Should fail: setQueueAttributes of bogus queue with no supplied attributes', function(done) {
+    it('Should fail: setQueueAttributes of bogus queue with no supplied attributes', function (done) {
       rsmq.setQueueAttributes({
         qname: "kjdsfh3h"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("No attribute was supplied");
         done();
       });
     });
-    it('Should fail: setQueueAttributes of bogus queue with supplied attributes', function(done) {
+    it('Should fail: setQueueAttributes of bogus queue with supplied attributes', function (done) {
       rsmq.setQueueAttributes({
         qname: "kjdsfh3h",
         vt: 1000
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Queue not found");
         done();
       });
     });
-    it('setQueueAttributes: Should return the queue with a new vt attribute', function(done) {
+    it('setQueueAttributes: Should return the queue with a new vt attribute', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         vt: 1234
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.vt.should.equal(1234);
         resp.delay.should.equal(0);
         resp.maxsize.should.equal(65536);
         done();
       });
     });
-    it('setQueueAttributes: Should return the queue with a new delay attribute', function(done) {
+    it('setQueueAttributes: Should return the queue with a new delay attribute', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         delay: 7
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.vt.should.equal(1234);
         resp.delay.should.equal(7);
         resp.maxsize.should.equal(65536);
         done();
       });
     });
-    it('setQueueAttributes: Should return the queue with a new maxsize attribute', function(done) {
+    it('setQueueAttributes: Should return the queue with a new maxsize attribute', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         maxsize: 2048
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.vt.should.equal(1234);
         resp.delay.should.equal(7);
         resp.maxsize.should.equal(2048);
         done();
       });
     });
-    it('setQueueAttributes: Should return the queue with a new attribute', function(done) {
+    it('setQueueAttributes: Should return the queue with a new attribute', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         maxsize: 65536,
         vt: 30,
         delay: 0
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.vt.should.equal(30);
         resp.delay.should.equal(0);
         resp.maxsize.should.equal(65536);
         done();
       });
     });
-    it('Should fail:setQueueAttributes: Should not accept too small maxsize', function(done) {
+    it('Should fail:setQueueAttributes: Should not accept too small maxsize', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         maxsize: 50
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("maxsize must be between 1024 and 65536");
         done();
       });
     });
-    it('Should fail:setQueueAttributes: Should not accept negative value', function(done) {
+    it('Should fail:setQueueAttributes: Should not accept negative value', function (done) {
       rsmq.setQueueAttributes({
         qname: queue1,
         vt: -5
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("vt must be between 0 and 9999999");
         done();
       });
     });
   });
-  describe('Messages', function() {
-    it('Should fail: Send a message to non-existing queue', function(done) {
+  describe('Messages', function () {
+    it('Should fail: Send a message to non-existing queue', function (done) {
       rsmq.sendMessage({
         qname: "rtlbrmpft",
         message: "foo"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Queue not found");
         done();
       });
     });
-    it('Should fail: Send a message without any parameters', function(done) {
-      rsmq.sendMessage({}, function(err, resp) {
+    it('Should fail: Send a message without any parameters', function (done) {
+      rsmq.sendMessage({}, function (err, resp) {
         err.message.should.equal("No qname supplied");
         done();
       });
     });
-    it('Should fail: Send a message without a message key', function(done) {
+    it('Should fail: Send a message without a message key', function (done) {
       rsmq.sendMessage({
         qname: queue1,
         messXage: "Hello"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Message must be a string");
         done();
       });
     });
-    it('Should fail: Send a message with message being a number', function(done) {
+    it('Should fail: Send a message with message being a number', function (done) {
       rsmq.sendMessage({
         qname: queue1,
         message: 123
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Message must be a string");
         done();
       });
     });
-    it('Send message 1 with existing Redis instance', function(done) {
+    it('Send message 1 with existing Redis instance', function (done) {
       rsmq2.sendMessage({
         qname: queue1,
         message: "Hello"
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         q1m1 = {
           id: resp,
@@ -337,7 +356,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
         done();
       });
     });
-    it('Send 1000 messages to queue2: succeed', function(done) {
+    it('Send 1000 messages to queue2: succeed', function (done) {
       var i, j, pq;
       pq = [];
       for (i = j = 0; j < 1000; i = ++j) {
@@ -346,7 +365,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
           message: "test message number:" + i
         });
       }
-      async.map(pq, rsmq.sendMessage, function(err, resp) {
+      async.map(pq, rsmq.sendMessage, function (err, resp) {
         var e, k, len;
         for (k = 0, len = resp.length; k < len; k++) {
           e = resp[k];
@@ -357,11 +376,11 @@ describe('Redis-Simple-Message-Queue Test', function() {
         done();
       });
     });
-    it('Send message 2', function(done) {
+    it('Send message 2', function (done) {
       rsmq.sendMessage({
         qname: queue1,
         message: "World"
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         q1m2 = {
           id: resp,
@@ -370,36 +389,36 @@ describe('Redis-Simple-Message-Queue Test', function() {
         done();
       });
     });
-    it('Receive a message. Should return message 1', function(done) {
+    it('Receive a message. Should return message 1', function (done) {
       rsmq2.receiveMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.id.should.equal(q1m1.id);
         done();
       });
     });
-    it('Receive a message. Should return message 2', function(done) {
+    it('Receive a message. Should return message 2', function (done) {
       rsmq.receiveMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.id.should.equal(q1m2.id);
         done();
       });
     });
-    it('Check queue properties. Should have 2 msgs', function(done) {
+    it('Check queue properties. Should have 2 msgs', function (done) {
       rsmq.getQueueAttributes({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.msgs.should.equal(2);
         resp.hiddenmsgs.should.equal(2);
         done();
       });
     });
-    it('Send message 3', function(done) {
+    it('Send message 3', function (done) {
       rsmq.sendMessage({
         qname: queue1,
         message: "Booo!!"
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         q1m3 = {
           id: resp,
@@ -408,156 +427,158 @@ describe('Redis-Simple-Message-Queue Test', function() {
         done();
       });
     });
-    it('Check queue properties. Should have 3 msgs', function(done) {
+    it('Check queue properties. Should have 3 msgs', function (done) {
       rsmq.getQueueAttributes({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.msgs.should.equal(3);
         resp.totalrecv.should.equal(2);
         done();
       });
     });
-    it('Pop a message. Should return message 3 and delete it', function(done) {
+    it('Pop a message. Should return message 3 and delete it', function (done) {
       rsmq.popMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.id.should.equal(q1m3.id);
         done();
       });
     });
-    it('Check queue properties. Should have 2 msgs', function(done) {
+    it('Check queue properties. Should have 2 msgs', function (done) {
       rsmq.getQueueAttributes({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.msgs.should.equal(2);
         resp.totalrecv.should.equal(3);
         done();
       });
     });
-    it('Pop a message. Should not return a message', function(done) {
+    it('Pop a message. Should not return a message', function (done) {
       rsmq.popMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(resp.id);
         done();
       });
     });
-    it('Should fail. Set the visibility of a non existing message', function(done) {
+    it('Should fail. Set the visibility of a non existing message', function (done) {
       rsmq.changeMessageVisibility({
         qname: queue1,
         id: "abcdefghij0123456789abcdefghij01",
         vt: 10
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(0);
         done();
       });
     });
-    it('Set new visibility timeout of message 2 to 10s', function(done) {
+    it('Set new visibility timeout of message 2 to 10s', function (done) {
       rsmq.changeMessageVisibility({
         qname: queue1,
         id: q1m2.id,
         vt: 10
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(1);
         done();
       });
     });
-    it('Receive a message. Should return nothing', function(done) {
+    it('Receive a message. Should return nothing', function (done) {
       rsmq.receiveMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(resp.id);
         done();
       });
     });
-    it('Set new visibility timeout of message 2 to 0s', function(done) {
+    it('Set new visibility timeout of message 2 to 0s', function (done) {
       rsmq.changeMessageVisibility({
         qname: queue1,
         id: q1m2.id,
         vt: 0
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(1);
         done();
       });
     });
-    it('Receive a message. Should return message 2', function(done) {
+    it('Receive a message. Should return message 2', function (done) {
       rsmq.receiveMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.id.should.equal(q1m2.id);
         done();
       });
     });
-    it('Receive a message. Should return nothing', function(done) {
+    it('Receive a message. Should return nothing', function (done) {
       rsmq.receiveMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(resp.id);
         done();
       });
     });
-    it('Should fail: Delete a message without supplying an id', function(done) {
+    it('Should fail: Delete a message without supplying an id', function (done) {
       rsmq.deleteMessage({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("No id supplied");
         done();
       });
     });
-    it('Should fail: Delete a message with invalid id', function(done) {
+    it('Should fail: Delete a message with invalid id', function (done) {
       rsmq.deleteMessage({
         qname: queue1,
         id: "sdafsdf"
-      }, function(err, resp) {
+      }, function (err, resp) {
         err.message.should.equal("Invalid id format");
         done();
       });
     });
-    it('Delete message 1. Should return 1', function(done) {
+    it('Delete message 1. Should return 1', function (done) {
       rsmq.deleteMessage({
         qname: queue1,
         id: q1m1.id
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(1);
         done();
       });
     });
-    it('Delete message 1 again. Should return 0', function(done) {
+    it('Delete message 1 again. Should return 0', function (done) {
       rsmq.deleteMessage({
         qname: queue1,
         id: q1m1.id
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(0);
         done();
       });
     });
-    it('Set new visibility timeout of message 1. Should return 0.', function(done) {
+    it('Set new visibility timeout of message 1. Should return 0.', function (done) {
       rsmq.changeMessageVisibility({
         qname: queue1,
         id: q1m1.id,
         vt: 10
-      }, function(err, resp) {
+      }, function (err, resp) {
         resp.should.equal(0);
         done();
       });
     });
-    it('Should fail: Send a message that is too long', function(done) {
+    it('Should fail: Send a message that is too long', function (done) {
       var j, results, text;
-      text = JSON.stringify((function() {
+      text = JSON.stringify((function () {
         results = [];
-        for (j = 0; j <= 15000; j++){ results.push(j); }
+        for (j = 0; j <= 15000; j++) {
+          results.push(j);
+        }
         return results;
       }).apply(this));
       rsmq.sendMessage({
         qname: queue1,
         message: text
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(resp);
         err.message.should.equal("Message too long");
         done();
       });
     });
-    it('Receive 1000 messages from queue2 and delete 500 (those where number is even)', function(done) {
+    it('Receive 1000 messages from queue2 and delete 500 (those where number is even)', function (done) {
       var i, j, pq;
       pq = [];
       for (i = j = 0; j < 1000; i = ++j) {
@@ -566,7 +587,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
           vt: 0
         });
       }
-      async.map(pq, rsmq.receiveMessage, function(err, resp) {
+      async.map(pq, rsmq.receiveMessage, function (err, resp) {
         var dq, e, k, len;
         dq = [];
         for (k = 0, len = resp.length; k < len; k++) {
@@ -580,7 +601,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
           });
           delete q2msgs[e.id];
         }
-        async.map(dq, rsmq.deleteMessage, function(err, resp) {
+        async.map(dq, rsmq.deleteMessage, function (err, resp) {
           var l, len1;
           for (l = 0, len1 = resp.length; l < len1; l++) {
             e = resp[l];
@@ -590,16 +611,16 @@ describe('Redis-Simple-Message-Queue Test', function() {
         });
       });
     });
-    it('GetQueueAttributes: Should return queue attributes', function(done) {
+    it('GetQueueAttributes: Should return queue attributes', function (done) {
       rsmq.getQueueAttributes({
         qname: queue2
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.msgs.should.equal(500);
         done();
       });
     });
-    it('Receive 500 messages from queue2 and delete them', function(done) {
+    it('Receive 500 messages from queue2 and delete them', function (done) {
       var i, j, pq;
       pq = [];
       for (i = j = 0; j < 500; i = ++j) {
@@ -608,7 +629,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
           vt: 0
         });
       }
-      async.map(pq, rsmq.receiveMessage, function(err, resp) {
+      async.map(pq, rsmq.receiveMessage, function (err, resp) {
         var dq, e, k, len;
         dq = [];
         for (k = 0, len = resp.length; k < len; k++) {
@@ -622,7 +643,7 @@ describe('Redis-Simple-Message-Queue Test', function() {
           });
           delete q2msgs[e.id];
         }
-        async.map(dq, rsmq.deleteMessage, function(err, resp) {
+        async.map(dq, rsmq.deleteMessage, function (err, resp) {
           var l, len1;
           for (l = 0, len1 = resp.length; l < len1; l++) {
             e = resp[l];
@@ -633,18 +654,18 @@ describe('Redis-Simple-Message-Queue Test', function() {
         });
       });
     });
-    it('Receive a message from queue2. Should return {}', function(done) {
+    it('Receive a message from queue2. Should return {}', function (done) {
       rsmq.receiveMessage({
         qname: queue2
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(resp.id);
         done();
       });
     });
-    return it('GetQueueAttributes: Should return queue attributes', function(done) {
+    return it('GetQueueAttributes: Should return queue attributes', function (done) {
       rsmq.getQueueAttributes({
         qname: queue2
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.totalrecv.should.equal(1500);
         resp.totalsent.should.equal(1000);
@@ -653,20 +674,20 @@ describe('Redis-Simple-Message-Queue Test', function() {
       });
     });
   });
-  describe('CLEANUP', function() {
-    it('Remove queue1', function(done) {
+  describe('CLEANUP', function () {
+    it('Remove queue1', function (done) {
       rsmq.deleteQueue({
         qname: queue1
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.should.equal(1);
         done();
       });
     });
-    it('Remove queue2', function(done) {
+    it('Remove queue2', function (done) {
       rsmq.deleteQueue({
         qname: queue2
-      }, function(err, resp) {
+      }, function (err, resp) {
         should.not.exist(err);
         resp.should.equal(1);
         done();


### PR DESCRIPTION
I know you setup a max size to avoid small servers running out of memory, but for our case we need to store some messages briefly larger than 65k, so I made an option that will allow for large messages as an override. This way it defaults to your limit, but users who need the extra umph can go at their own risk