### PR TITLE
Add noauth support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -50,6 +50,8 @@ class RedisSMQ extends EventEmitter
 			@redis = opts.client
 		else
 			@redis = RedisInst.createClient(opts.port, opts.host, opts.options)
+			if opts.no_auth
+  				@redis.auth opts.no_auth
 
 		@connected = @redis.connected or false
 


### PR DESCRIPTION
Just adding the NOAUTH Authentication support to Redis connection when creating new object

e.g. 

```
new RedisSMQ( {
    host: process.env.REDIS_HOST, 
    port: process.env.REDIS_PORT,
    no_auth: process.env.REDIS_NO_AUTH_PW, 
    ns: "rsmq"
} )
``` 