### PR TITLE
fix mismatch btw comment and code : interval in example simple-queue.js

### DIFF
--- a/examples/simple-queue.js
+++ b/examples/simple-queue.js
@@ -72,5 +72,5 @@ function receiveMessageLoop(queuename) {
 				console.log("no available message in queue..");
 			}
 		});
-	}, 500);
+	}, 2500);
 }


### PR DESCRIPTION
comment on line https://github.com/smrchy/rsmq/compare/master...pitachips:fix?expand=1#diff-66f4e6c5b32849a89373d99302dd0f6cL49 says 2.5 second interval, but code sets 0.5 second interval.

Just a trivial fix, but I found this project very useful and wanted to contribute!