### PR TITLE
Allow password in constructor (fixed #112)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,7 @@ declare namespace RedisSMQ {
 		ns?: string;
 		options?: ClientOpts;
 		client?: RedisClient;
+		password?: string;
 	}
 
 	interface BaseOptions {


### PR DESCRIPTION
This PR fixes #112 by adding the "password" property to the constructor interface.