### PR TITLE
Fix redis client opts pass-thru

### DIFF
--- a/_src/index.ts
+++ b/_src/index.ts
@@ -65,7 +65,7 @@ class RedisSMQ extends EventEmitter {
 			this.redis = opts.client
 		}
 		else {
-			this.redis = RedisInst.createClient(opts)
+			this.redis = RedisInst.createClient(opts.options)
 		}
 
 		this.connected = this.redis.connected || false;

--- a/index.js
+++ b/index.js
@@ -521,7 +521,7 @@ class RedisSMQ extends EventEmitter {
             this.redis = opts.client;
         }
         else {
-            this.redis = RedisInst.createClient(opts);
+            this.redis = RedisInst.createClient(opts.options);
         }
         this.connected = this.redis.connected || false;
         if (this.connected) {


### PR DESCRIPTION
Without this fix, this just does not work.

`this.rsmq = new RedisSMQ({ options: { url: connectionString } });`

The documentation is stating:
> options (Object): optional (Default: {}) The Redis options object.

But the options were not passed to the newly created redis client.